### PR TITLE
Make shared libs for CUDA modules depend on host and device checksums

### DIFF
--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -172,7 +172,7 @@ def extension_from_string(toolchain, name, source_string,
     If *debug_recompile*, messages are printed indicating whether a
     recompilation is taking place.
     """
-    mod_name, ext_file, recompiled = \
+    checksum, mod_name, ext_file, recompiled = \
         compile_from_string(toolchain,
                             name, source_string,
                             source_name,
@@ -373,7 +373,7 @@ def compile_from_string(toolchain, name, source_string,
                 else:
                     if check_deps(info.dependencies) and check_source(
                             mod_cache_dir_m.sub(info.source_name)):
-                        return mod_name, ext_file, False
+                        return hex_checksum, mod_name, ext_file, False
             else:
                 if debug_recompile:
                     print "recompiling for non-existent cache dir (%s)." % (
@@ -403,7 +403,7 @@ def compile_from_string(toolchain, name, source_string,
                 source_name=source_name), info_file)
             info_file.close()
 
-        return mod_name, ext_file, True
+        return hex_checksum, mod_name, ext_file, True
     except:
         cleanup_m.error_clean_up()
         raise


### PR DESCRIPTION
When building a CudaModule, the shared lib is not re-linked if the
cache is hit for both the host and the device module. However, this
does not mean that the host module was also linked against that very
device module we found in cache, which is what we want.

To make sure we don't accidentially reuturn a shared lib with wrong
linkage when we hit the cache twice, the name of the shared lib
contains the hex checksums for both the host and device code.

This allows shared libraries for the same host module linked against
different device modules to co-exist in cache without the need to
re-compile the object files.
