### PR TITLE
Cast str and encode checksums for python 3

### DIFF
--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -289,8 +289,8 @@ def compile_from_string(toolchain, name, source_string,
             import md5
             checksum = md5.new()
 
-        checksum.update(source_string)
-        checksum.update(str(toolchain.abi_id()))
+        checksum.update(source_string.encode('utf-8'))
+        checksum.update(str(toolchain.abi_id()).encode('utf-8'))
         return checksum.hexdigest()
 
     def load_info(info_path):

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -416,10 +416,10 @@ def guess_toolchain():
     if result != 0:
         raise ToolchainGuessError("compiler version query failed: "+stderr)
 
-    if "Free Software Foundation" in version:
+    if "Free Software Foundation" in str(version):
         if "-Wstrict-prototypes" in kwargs["cflags"]:
             kwargs["cflags"].remove("-Wstrict-prototypes")
-        if "darwin" in version:
+        if "darwin" in str(version):
             # Are we running in 32-bit mode?
             # The python interpreter may have been compiled as a Fat binary
             # So we need to check explicitly how we're running

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name="codepy",
           'Topic :: Utilities',
           ],
 
-      author=u"Andreas Kloeckner",
+      author="Andreas Kloeckner",
       url="http://mathema.tician.de/software/codepy",
       author_email="inform@tiker.net",
       license="MIT",


### PR DESCRIPTION
In addition to these changes, line 153 in toolchain.py throws “Type str doesn't support the buffer API”. It wasn't obvious to me what else needed to be cast as a string, so I tried replacing 153 in toolchain.py with "lines = join_continued_lines(str(stdout.split("\n")))" and 29 in tools.py with "return str(result)", and the same error came up both times.
