### PR TITLE
Fixed problem with toolchain.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ setuptools*tar.gz
 setuptools.pth
 distribute*egg
 distribute*tar.gz
+.idea

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -429,6 +429,19 @@ def guess_toolchain():
                 kwargs["cflags"].extend(['-arch', 'i386'])
 
         return GCCToolchain(**kwargs)
+    elif "Apple LLVM" in version and "clang" in version:
+        if "-Wstrict-prototypes" in kwargs["cflags"]:
+            kwargs["cflags"].remove("-Wstrict-prototypes")
+        if "darwin" in version:
+            # Are we running in 32-bit mode?
+            # The python interpreter may have been compiled as a Fat binary
+            # So we need to check explicitly how we're running
+            # And update the cflags accordingly
+            import sys
+            if sys.maxint == 0x7fffffff:
+                kwargs["cflags"].extend(['-arch', 'i386'])
+
+        return GCCToolchain(**kwargs)
     else:
         raise ToolchainGuessError("unknown compiler")
 


### PR DESCRIPTION
on mac with xcode 5 compiler has dropped looked for string
'Free Software Foundation'
Added elif that looks for strings 'Apple LLVM' and 'clang'
and returns as it did before, seems to work
