### PR TITLE
Including cuda.h by default, adding use_runtime function

### DIFF
--- a/codepy/cuda.py
+++ b/codepy/cuda.py
@@ -21,6 +21,12 @@ class CudaModule(object):
         self.body = []
         self.boost_module = boost_module
         self.boost_module.add_to_preamble([cgen.Include('cuda.h')])
+        self.add_to_preamble([cgen.Include('cuda.h')])
+
+    def use_runtime(self):
+        """Use the CUDA Runtime API"""
+        self.boost_module.add_to_preamble([cgen.Include('cuda_runtime.h')])
+        self.add_to_preamble([cgen.Include('cuda_runtime.h')])
 
     def add_to_preamble(self, pa):
         self.preamble.extend(pa)


### PR DESCRIPTION
- cuda.h should be included by default like it is for the boost module.
- Added a function to include cuda_runtime.h in a more elegant manner instead of having to add it the preamble for both the Cuda and Boost modules.
