### PR TITLE
More python3 fixes

### DIFF
--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -310,11 +310,7 @@ def compile_from_string(toolchain, name, source_string,
         return checksum.hexdigest()
 
     def load_info(info_path):
-        try:
-            from cPickle import load
-        except ImportError:
-            # py3
-            from pickle import load
+        from six.moves.cPickle import load
 
         try:
             info_file = open(info_path, 'rb')
@@ -413,11 +409,7 @@ def compile_from_string(toolchain, name, source_string,
             toolchain.build_extension(ext_file, source_paths, debug=debug)
 
         if info_path is not None:
-            try:
-                from cPickle import dump
-            except ImportError:
-                # py3
-                from pickle import dump
+            from six.moves.cPickle import dump
 
             info_file = open(info_path, "wb")
             dump(_SourceInfo(

--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -287,7 +287,7 @@ def compile_from_string(toolchain, name, source_string,
     def write_source(name):
         for i, source in enumerate(source_string):
             outf = open(name[i], "w" if not source_is_binary else "wb")
-            outf.write(str(source))
+            outf.write(source)
             outf.close()
 
     def calculate_hex_checksum():

--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -3,6 +3,7 @@
 from __future__ import division
 from codepy import CompileError
 from pytools import Record
+import six
 
 __copyright__ = "Copyright (C) 2008 Andreas Kloeckner"
 
@@ -230,7 +231,8 @@ def compile_from_string(toolchain, name, source_string,
     """
 
     # first ensure that source strings and names are lists
-    if isinstance(source_string, str) or isinstance(source_string, bytes):
+    if isinstance(source_string, six.string_types) \
+            or (source_is_binary and isinstance(source_string, six.binary_type)):
         source_string = [source_string]
 
     if isinstance(source_name, str):

--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -390,7 +390,7 @@ def compile_from_string(toolchain, name, source_string,
                             mod_cache_dir_m.path)
             else:
                 if check_deps(info.dependencies) and check_source(
-                        mod_cache_dir_m.sub(info.source_name)):
+                        [mod_cache_dir_m.sub(x) for x in info.source_name]):
                     return hex_checksum, mod_name, ext_file, False
         else:
             if debug_recompile:

--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -315,7 +315,7 @@ def compile_from_string(toolchain, name, source_string,
             from pickle import load
 
         try:
-            info_file = open(info_path)
+            info_file = open(info_path, 'rb')
         except IOError:
             raise _InvalidInfoFile()
 

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -1,6 +1,6 @@
 """Toolchains for Just-in-time Python extension compilation."""
 
-from __future__ import division
+from __future__ import division, print_function
 
 __copyright__ = "Copyright (C) 2008,9 Andreas Kloeckner, Bryan Catanzaro"
 
@@ -160,15 +160,15 @@ class GCCLikeToolchain(Toolchain):
 
         from pytools.prefork import call
         if debug:
-            print " ".join(cc_cmdline)
+            print(" ".join(cc_cmdline))
 
         result = call(cc_cmdline)
 
         if result != 0:
             import sys
-            print >> sys.stderr, "FAILED compiler invocation:", \
-                    " ".join(cc_cmdline)
-            raise CompileError, "module compilation failed"
+            print("FAILED compiler invocation:" +
+                  " ".join(cc_cmdline), file=sys.stderr)
+            raise CompileError("module compilation failed")
 
     def build_extension(self, ext_file, source_files, debug=False):
         cc_cmdline = (
@@ -178,15 +178,15 @@ class GCCLikeToolchain(Toolchain):
 
         from pytools.prefork import call
         if debug:
-            print " ".join(cc_cmdline)
+            print(" ".join(cc_cmdline))
 
         result = call(cc_cmdline)
 
         if result != 0:
             import sys
-            print >> sys.stderr, "FAILED compiler invocation:", \
-                    " ".join(cc_cmdline)
-            raise CompileError, "module compilation failed"
+            print("FAILED compiler invocation:" + " ".join(cc_cmdline),
+                  file=sys.stderr)
+            raise CompileError("module compilation failed")
 
     def link_extension(self, ext_file, object_files, debug=False):
         cc_cmdline = (
@@ -196,15 +196,15 @@ class GCCLikeToolchain(Toolchain):
 
         from pytools.prefork import call
         if debug:
-            print " ".join(cc_cmdline)
+            print(" ".join(cc_cmdline))
 
         result = call(cc_cmdline)
 
         if result != 0:
             import sys
-            print >> sys.stderr, "FAILED compiler invocation:", \
-                    " ".join(cc_cmdline)
-            raise CompileError, "module compilation failed"
+            print("FAILED compiler invocation:" + " ".join(cc_cmdline),
+                  file=sys.stderr)
+            raise CompileError("module compilation failed")
 
 
 
@@ -315,23 +315,22 @@ class NVCCToolchain(GCCLikeToolchain):
                 )
 
         if debug:
-            print " ".join(cc_cmdline)
+            print(" ".join(cc_cmdline))
 
         result, stdout, stderr = call_capture_output(cc_cmdline)
-        print stderr
-        print stdout
+        print(stderr)
+        print(stdout)
 
         if "error" in stderr:
             # work around a bug in nvcc, which doesn't provide a non-zero
             # return code even if it failed.
             result = 1
 
-
         if result != 0:
             import sys
-            print >> sys.stderr, "FAILED compiler invocation:", \
-                    " ".join(cc_cmdline)
-            raise CompileError, "module compilation failed"
+            print("FAILED compiler invocation:" + " ".join(cc_cmdline),
+                  file=sys.stderr)
+            raise CompileError("module compilation failed")
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name="codepy",
           "pytools>=2015.1.2",
           "numpy>=1.6",
           "appdirs>=1.4.0",
+          "six",
           "cgen",
           ],
 

--- a/test/test_two_stage_compile.py
+++ b/test/test_two_stage_compile.py
@@ -1,0 +1,33 @@
+from codepy.toolchain import guess_toolchain
+from codepy.jit import compile_from_string
+from ctypes import CDLL
+
+def test():
+    toolchain = guess_toolchain()
+
+    MODULE_CODE = """
+    extern "C" {
+        int const greet()
+        {
+            return 1;
+        }
+    }
+    """
+
+
+    # compile to object file
+    _, _, obj_path, _ = compile_from_string(toolchain, 'module', MODULE_CODE,
+                                            object=True)
+    # and then to shared lib
+    with open(obj_path, 'rb') as file:
+        obj = file.read()
+
+    _, _, ext_file, _ = compile_from_string(
+        toolchain, 'module', obj, source_name=['module.o'],
+        object=False, source_is_binary=True)
+
+    # test module
+    dll = CDLL(ext_file)
+    _fn = getattr(dll, 'greet')
+    _fn.restype = int
+    assert _fn() == 1

--- a/test/test_two_stage_compile.py
+++ b/test/test_two_stage_compile.py
@@ -2,6 +2,7 @@ from codepy.toolchain import guess_toolchain
 from codepy.jit import compile_from_string
 from ctypes import CDLL
 
+
 def test():
     toolchain = guess_toolchain()
 
@@ -13,8 +14,6 @@ def test():
         }
     }
     """
-
-
     # compile to object file
     _, _, obj_path, _ = compile_from_string(toolchain, 'module', MODULE_CODE,
                                             object=True)


### PR DESCRIPTION
@inducer sorry to do this after you bumped the version, but I found a small bug in the python3 implementation for the source_write in jit.py

...

Which lead me to add a unit test.

From which I discovered many other python3 incompatibilities

Which I fixed.

And then realized the caching still had some bugs -- now fixed -- which probably means I haven't fully tested it in loopy

So I wrote this non-sequitur of a PR message :smile: 

On the plus side, codepy is much more python3 friendly after this

p.s. I don't know if you have a CI tester on the gitlab, but I can re-open this it there if so.  Also, I don't have a python2.6 implementation handy to test on, which we should probably do