### PR TITLE
Remove Toolchain::get_dependencies extra entries

### DIFF
--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -168,7 +168,7 @@ class GCCLikeToolchain(Toolchain):
             raise CompileError(f"getting dependencies failed: {stderr}")
 
         lines = join_continued_lines(stdout.split("\n"))
-        lines = [line for line in lines if not line.strip() and line.strip()[0]=='#']
+        lines = [line for line in lines if not (line.strip() and line.strip()[0]=="#")]
         from pytools import flatten
         return set(flatten(
             line.split()[2:] for line in lines))

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -168,6 +168,7 @@ class GCCLikeToolchain(Toolchain):
             raise CompileError(f"getting dependencies failed: {stderr}")
 
         lines = join_continued_lines(stdout.split("\n"))
+        lines = [line for line in lines if not (len(line.strip())>0 and line.strip()[0]=='#')]
         from pytools import flatten
         return set(flatten(
             line.split()[2:] for line in lines))

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -168,7 +168,8 @@ class GCCLikeToolchain(Toolchain):
             raise CompileError(f"getting dependencies failed: {stderr}")
 
         lines = join_continued_lines(stdout.split("\n"))
-        lines = [line for line in lines if not (line.strip() and line.strip()[0]=="#")]
+        lines = [line for line in lines
+                 if not (line.strip() and line.strip()[0] == "#")]
         from pytools import flatten
         return set(flatten(
             line.split()[2:] for line in lines))

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -168,7 +168,7 @@ class GCCLikeToolchain(Toolchain):
             raise CompileError(f"getting dependencies failed: {stderr}")
 
         lines = join_continued_lines(stdout.split("\n"))
-        lines = [line for line in lines if not (len(line.strip())>0 and line.strip()[0]=='#')]
+        lines = [line for line in lines if not line.strip() and line.strip()[0]=='#']
         from pytools import flatten
         return set(flatten(
             line.split()[2:] for line in lines))


### PR DESCRIPTION
I'm using the `icx` compiler from OneAPI to compile OpenMP offload code. The following command used to query dependencies:
`icx -M -O3 -g -fPIC -Wall -std=c99 -qopenmp -fopenmp-targets=spir64 /home/u83311/tmp/devito-jitcache-uid85311/260030861f24c1e2bc347afa986d9632be371ca9.c`
returns the expected headers, as well as lines such as:
`# __CLANG_OFFLOAD_BUNDLE____START__ openmp-spir64`

which then later lead to issues because these are not files. I am not sure, what would be the ideal solution, perhaps filter out lines beginning with `#`?