### PR TITLE
Replace uses of deprecated imp module

### DIFF
--- a/codepy/cuda.py
+++ b/codepy/cuda.py
@@ -105,7 +105,7 @@ class CudaModule:
             module_path = os.path.join(destination_base, mod_name
                                        + host_toolchain.so_ext)
             try:
-                from imp import load_dynamic
+                from codepy.tools import load_dynamic
                 return load_dynamic(mod_name, module_path)
             except Exception:
                 return link_extension(host_toolchain,

--- a/codepy/jit.py
+++ b/codepy/jit.py
@@ -206,7 +206,7 @@ def extension_from_string(toolchain, name, source_string,
                             cache_dir, debug, wait_on_error, debug_recompile,
                             False, sleep_delay=sleep_delay)
     # try loading it
-    from imp import load_dynamic
+    from codepy.tools import load_dynamic
     return load_dynamic(mod_name, ext_file)
 
 
@@ -484,7 +484,7 @@ def link_extension(toolchain, objects, mod_name, cache_dir=None,
             raise
 
     # try loading it
-    from imp import load_dynamic
+    from codepy.tools import load_dynamic
     return load_dynamic(mod_name, destination)
 
 

--- a/codepy/libraries.py
+++ b/codepy/libraries.py
@@ -115,10 +115,10 @@ def add_boost_numeric_bindings(toolchain):
 
 def add_numpy(toolchain):
     def get_numpy_incpath():
-        from imp import find_module
-        file, pathname, descr = find_module("numpy")
+        from importlib.util import find_spec
+        spec = find_spec("numpy")
         from os.path import join
-        return join(pathname, "core", "include")
+        return join(spec.submodule_search_locations[0], "core", "include")
 
     toolchain.add_library("numpy", [get_numpy_incpath()], [], [])
 

--- a/codepy/tools.py
+++ b/codepy/tools.py
@@ -30,3 +30,24 @@ def join_continued_lines(lines):
             warn("line continuation at end of file")
 
     return result
+
+
+def load_dynamic(name: str, path: str):
+    """Implementation of ``imp.load_dynamic`` based on :mod:`importlib`."""
+    # https://github.com/python/cpython/pull/105951
+
+    from importlib.machinery import ExtensionFileLoader
+
+    loader = ExtensionFileLoader(name, path)
+
+    from importlib.util import module_from_spec, spec_from_loader
+
+    spec = spec_from_loader(name, loader)
+    module = module_from_spec(spec)
+
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+
+    loader.exec_module(module)
+    return module


### PR DESCRIPTION
The ``imp`` module was removed in Python 3.12, so I'm guessing this stuff wasn't used anywhere..