### PR TITLE
Strictly type everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
                 . ./ci-support-v0
 
                 build_py_project_in_venv
-                python -m mypy codepy
+                python -m mypy codepy test examples
 
     docs:
         name: Documentation

--- a/codepy/bpl.py
+++ b/codepy/bpl.py
@@ -1,38 +1,47 @@
 """Convenience interface for using CodePy with Boost.Python."""
 
+from collections.abc import Callable, Iterable
 from dataclasses import replace
+from types import ModuleType
+from typing import Any
+
+from cgen import FunctionBody, Generable, Module, Struct
+
+from codepy.toolchain import Toolchain
 
 
 class BoostPythonModule:
-    def __init__(self, name="module", max_arity=None,
-            use_private_namespace=True):
+    def __init__(self,
+                 name: str = "module",
+                 max_arity: int | str | None = None,
+                 use_private_namespace: bool = True) -> None:
         self.name = name
-        self.preamble = []
-        self.mod_body = []
-        self.init_body = []
-
-        self.has_codepy_include = False
-        self.has_raw_function_include = False
         self.max_arity = max_arity
         self.use_private_namespace = use_private_namespace
 
-    def add_to_init(self, body):
+        self.preamble: list[Generable] = []
+        self.mod_body: list[Generable] = []
+        self.init_body: list[Generable] = []
+        self.has_codepy_include = False
+        self.has_raw_function_include = False
+
+    def add_to_init(self, body: Iterable[Generable]) -> None:
         """Add the blocks or statements contained in the iterable *body* to the
         module initialization function.
         """
         self.init_body.extend(body)
 
-    def add_to_preamble(self, pa):
+    def add_to_preamble(self, pa: Iterable[Generable]) -> None:
         self.preamble.extend(pa)
 
-    def add_to_module(self, body):
+    def add_to_module(self, body: Iterable[Generable]) -> None:
         """Add the :class:`cgen.Generable` instances in the iterable
         *body* to the body of the module *self*.
         """
 
         self.mod_body.extend(body)
 
-    def add_codepy_include(self):
+    def add_codepy_include(self) -> None:
         if self.has_codepy_include:
             return
 
@@ -43,7 +52,7 @@ class BoostPythonModule:
             ])
         self.has_codepy_include = True
 
-    def add_raw_function_include(self):
+    def add_raw_function_include(self) -> None:
         if self.has_raw_function_include:
             return
 
@@ -54,7 +63,7 @@ class BoostPythonModule:
             ])
         self.has_raw_function_include = True
 
-    def expose_vector_type(self, name, py_name=None):
+    def expose_vector_type(self, name: str, py_name: str | None = None) -> None:
         self.add_codepy_include()
 
         if py_name is None:
@@ -71,34 +80,39 @@ class BoostPythonModule:
                     ".def(codepy::no_compare_indexing_suite<cl>())"),
                 ]))
 
-    def add_function(self, func):
+    def add_function(self, func: FunctionBody) -> None:
         """Add a function to be exposed. *func* is expected to be a
         :class:`cgen.FunctionBody`.
         """
+        from cgen import Statement
 
         self.mod_body.append(func)
-        from cgen import Statement
         self.init_body.append(
                 Statement(
                     'boost::python::def("{}", &{})'.format(
                         func.fdecl.name, func.fdecl.name)))
 
-    def add_raw_function(self, func):
+    def add_raw_function(self, func: FunctionBody) -> None:
         """Add a function to be exposed using boost::python::raw_function.
         *func* is expected to be a :class:`cgen.FunctionBody`.
         """
-        self.mod_body.append(func)
         from cgen import Statement
+
+        self.mod_body.append(func)
         self.add_raw_function_include()
+
         raw_function = f"boost::python::raw_function(&{func.fdecl.name})"
         self.init_body.append(
             Statement(
                 'boost::python::def("{}", {})'.format(
                     func.fdecl.name, raw_function)))
 
-    def add_struct(self,
-            struct, py_name=None, py_member_name_transform=lambda x: x,
-            by_value_members=None):
+    def add_struct(
+            self,
+            struct: Struct,
+            py_name: str | None = None,
+            py_member_name_transform: Callable[[str], str] = lambda x: x,
+            by_value_members: set[str] | None = None) -> None:
         if by_value_members is None:
             by_value_members = set()
 
@@ -111,6 +125,11 @@ class BoostPythonModule:
 
         member_defs = []
         for f in struct.fields:
+            if not hasattr(f, "name"):
+                raise TypeError(
+                    f"Invalid type {type(f)} of struct field. Only named fields "
+                    "are supported for code generation")
+
             py_f_name = py_member_name_transform(f.name)
             tp_lines, _ = f.get_decl_pair()
             if f.name in by_value_members or tp_lines[0].startswith("numpy_"):
@@ -131,20 +150,20 @@ class BoostPythonModule:
                         py_name, "".join(member_defs))),
                 ]))
 
-    def generate(self):
+    def generate(self) -> Module:
         """Generate (i.e. yield) the source code of the
         module line-by-line.
         """
 
-        from cgen import Block, Define, Include, Line, Module, PrivateNamespace
+        from cgen import Block, Define, Include, Line, PrivateNamespace
 
-        body = []
+        body: list[Generable] = []
 
         if self.max_arity is not None:
-            body.append(Define("BOOST_PYTHON_MAX_ARITY", self.max_arity))
+            body.append(Define("BOOST_PYTHON_MAX_ARITY", str(self.max_arity)))
 
         if self.use_private_namespace:
-            mod_body = [PrivateNamespace(self.mod_body)]
+            mod_body: list[Generable] = [PrivateNamespace(self.mod_body)]
         else:
             mod_body = self.mod_body
 
@@ -160,7 +179,7 @@ class BoostPythonModule:
 
         return Module(body)
 
-    def compile(self, toolchain, **kwargs):
+    def compile(self, toolchain: Toolchain, **kwargs: Any) -> ModuleType:
         """Return the extension module generated from the code described
         by *self*. If necessary, build the code using *toolchain* with
         :func:`codepy.jit.extension_from_string`. Any keyword arguments
@@ -173,5 +192,8 @@ class BoostPythonModule:
         add_boost_python(toolchain)
 
         from codepy.jit import extension_from_string
-        return extension_from_string(toolchain, self.name,
+
+        return extension_from_string(
+                toolchain,
+                self.name,
                 "{}\n".format(self.generate()), **kwargs)

--- a/codepy/toolchain.py
+++ b/codepy/toolchain.py
@@ -29,6 +29,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from typing import Any
 
+from typing_extensions import Self
+
 from codepy import CompileError
 
 
@@ -45,7 +47,7 @@ class Toolchain(ABC):
 
     features: set[str]
 
-    def copy(self, **kwargs: Any) -> "Toolchain":
+    def copy(self, **kwargs: Any) -> Self:
         from warnings import warn
         warn(f"'{type(self).__name__}.copy' is deprecated. This is now a "
              "dataclass and should be used with the standard 'replace'.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,12 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
+    "cgen>=2020.1",
     "numpy>=1.6",
-    "pytools>=2022.1.14",
     "platformdirs>=2.2.0",
-    "cgen>=2020.1"
+    "pytools>=2022.1.14",
+    # NOTE: for Self (requires python >=3.11)
+    "typing-extensions>=4.5",
 ]
 
 [project.optional-dependencies]
@@ -88,23 +90,6 @@ warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = [
-    "cgen.*",
+    "pycuda.*",
 ]
 ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [
-    "codepy.bpl",
-    "codepy.elementwise",
-    "codepy.cuda",
-]
-# NOTE: the strict option is global, the checks must be disabled one by one
-warn_unused_ignores = false
-check_untyped_defs = false
-allow_subclassing_any = true
-allow_any_generics = true
-allow_untyped_calls = true
-allow_incomplete_defs = true
-allow_untyped_defs = true
-implicit_reexport = true
-warn_return_any = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/inducer/cgen.git#egg=cgen

--- a/test/test_identical_symbols.py
+++ b/test/test_identical_symbols.py
@@ -1,7 +1,9 @@
+from types import ModuleType
+
 import pytest
 
 
-def make_greet_mod(greeting):
+def make_greet_mod(greeting: str) -> ModuleType:
     from cgen import (
         Block,
         Const,
@@ -19,7 +21,7 @@ def make_greet_mod(greeting):
     mod.add_function(
             FunctionBody(
                 FunctionDeclaration(Const(Pointer(Value("char", "greet"))), []),
-                Block([Statement('return "%s"' % greeting)])
+                Block([Statement(f'return "{greeting}"')])
                 ))
 
     from codepy.toolchain import guess_toolchain
@@ -29,7 +31,7 @@ def make_greet_mod(greeting):
 @pytest.mark.xfail(reason="You probably don't have "
         "Boost.Python installed where I am looking for it, "
         "and that's OK.")
-def test_identical_symbols():
+def test_identical_symbols() -> None:
     us = make_greet_mod("Hi there")
     aussie = make_greet_mod("G'day")
 

--- a/test/test_two_stage_compile.py
+++ b/test/test_two_stage_compile.py
@@ -4,7 +4,7 @@ from codepy.jit import compile_from_string
 from codepy.toolchain import guess_toolchain
 
 
-def test():
+def test() -> None:
     toolchain = guess_toolchain()
 
     module_code = """


### PR DESCRIPTION
This adds strict typing to the remaining modules as well and removes the ignore on `cgen`, since that's strictly typed now too.